### PR TITLE
master back to develop (#5)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 #### 1.0.2
 * More GHU Transient Changes
 
+#### 1.0.1
+* Hotfix GHU cache clear sync
+
 #### 1.0.0
 * Tested in production at scale for several days, ready to call plugin released and out of beta
 * Fixed github updater double caching issues and removed transients from GHU to reduce transient cache overhead, especially useful for reducing VARNISH / REDIS bandwidth issues.

--- a/wp-rest-cache.php
+++ b/wp-rest-cache.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/WordPress-Phoenix/wordpress-rest-cache
  * Description: A solution to caching REST data calls without relying on transients or wp_options tables. Note: for multisite "Network Activate", table may need manually created before activation.
  * Author: scarstens
- * Version: 1.0.0
+ * Version: 1.0.2
  * Author URI: http://github.com/scarstens
  * License: GPL V2
  * Text Domain: rest_cache


### PR DESCRIPTION
- Ready to come out of beta (#2)
- sync clearing cache with github updater
- upgrade utility
- adjust rest table columns
- fixes GHU issues with caching vs transients
- have rest cache admin delete function use new utility
- add transient disabler to ghu plugin
- version bump
- Update changelog.md
- I think we really need that 's' (#3)
- version bump
- changelog
- version bump
