### PR TITLE
Add filter

### DIFF
--- a/inc/class-wrc-utility.php
+++ b/inc/class-wrc-utility.php
@@ -11,15 +11,16 @@ class WRC_Utility {
 	/**
 	 * Utility to easily delete cache by exact column value
 	 *
-	 * @param $column
-	 * @param $value
+	 * @param $clear_cache
 	 *
 	 * @return false|int
 	 */
-	public static function clear_cache_by( $column, $value ) {
+	public static function clear_cache_by( $clear_cache ) {
 		global $wpdb;
 
-		return $wpdb->delete( $wpdb->base_prefix . WP_Rest_Cache::$table, array( $column => $value ) );
+		array_filter( $clear_cache, function( $args ) use ( $wpdb ) {
+			return $wpdb->delete( $wpdb->base_prefix . WP_Rest_Cache::$table, $args );
+		} );
 	}
 
 	/**
@@ -28,7 +29,23 @@ class WRC_Utility {
 	 * @return int number of deleted cache rows
 	 */
 	public static function clear_ghu_cache() {
-		return self::clear_cache_by( 'rest_domain', 'https://api.github.com' );
+		$clear_cache = array(
+			array( 'rest_domain' => 'https://api.github.com' ),
+			array( 'rest_args' => 'GitHub Updater' ),
+		);
+
+		/**
+		 * Filters array of arrays containing key/value pairs of column/value pairs
+		 * for removal from wp_rest_cache table.
+		 *
+		 * @param array $clear_cache Array of arrays containing key/value pairs for removal.
+		 *                           Default contains GitHub and GitHub Updater values.
+		 *
+		 * @return array $clear_cache Merged array.
+		 */
+		$clear_cache = apply_filters( 'wp_rest_cache_clear_extra', $clear_cache );
+
+		return self::clear_cache_by( $clear_cache );
 	}
 
 }

--- a/inc/class-wrc-utility.php
+++ b/inc/class-wrc-utility.php
@@ -11,15 +11,15 @@ class WRC_Utility {
 	/**
 	 * Utility to easily delete cache by exact column value
 	 *
-	 * @param $clear_cache
+	 * @param $clear_api_calls
 	 *
 	 * @return false|int
 	 */
-	public static function clear_cache_by( $clear_cache ) {
+	public static function clear_cache_by( $clear_api_calls ) {
 		global $wpdb;
 
-		array_filter( $clear_cache, function( $args ) use ( $wpdb ) {
-			return $wpdb->delete( $wpdb->base_prefix . WP_Rest_Cache::$table, $args );
+		array_filter( $clear_api_calls, function( $arr ) use ( $wpdb ) {
+			return $wpdb->delete( $wpdb->base_prefix . WP_Rest_Cache::$table, $arr );
 		} );
 	}
 
@@ -29,23 +29,22 @@ class WRC_Utility {
 	 * @return int number of deleted cache rows
 	 */
 	public static function clear_ghu_cache() {
-		$clear_cache = array(
+		$clear_api_calls = array(
 			array( 'rest_domain' => 'https://api.github.com' ),
-			array( 'rest_args' => 'GitHub Updater' ),
 		);
 
 		/**
 		 * Filters array of arrays containing key/value pairs of column/value pairs
 		 * for removal from wp_rest_cache table.
 		 *
-		 * @param array $clear_cache Array of arrays containing key/value pairs for removal.
-		 *                           Default contains GitHub and GitHub Updater values.
+		 * @param array $clear_columns Array of arrays containing key/value pairs for removal.
+		 *                             Default contains GitHub and GitHub Updater values.
 		 *
-		 * @return array $clear_cache Merged array.
+		 * @return array $clear_columns Merged array.
 		 */
-		$clear_cache = apply_filters( 'wp_rest_cache_clear_extra', $clear_cache );
+		$clear_api_calls = apply_filters( 'wp_rest_cache_clear_extra', $clear_api_calls );
 
-		return self::clear_cache_by( $clear_cache );
+		return self::clear_cache_by( $clear_api_calls );
 	}
 
 }

--- a/wp-rest-cache.php
+++ b/wp-rest-cache.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'WP_Rest_Cache' ) ) {
 			$this->load_classes();
 
 			// initialize plugin during init
-			add_action( 'init', array( $this, 'init' ) );
+			add_action( 'init', array( $this, 'init' ), 5 );
 
 			// init for use with logged in users, see this::authenticated_init for more details
 			add_action( 'init', array( $this, 'authenticated_init' ) );


### PR DESCRIPTION
Adds filter to allow for user adding additional domains to clear.

Usage:

``` php
add_filter( 'wp_rest_cache_clear_extra', function( $clear_api_calls ) {
    $extra = array(
        array( 'rest_domain' => 'https://bitbucket.org' ),
        array( 'rest_domain' => 'https://gitlab.com' ),
    );

    return array_merge( $clear_api_calls, $extra );
}, 10, 1 );
```
