### PR TITLE
set $table_version_key on activation

### DIFF
--- a/wp-rest-cache.php
+++ b/wp-rest-cache.php
@@ -159,7 +159,8 @@ if ( ! class_exists( 'WP_Rest_Cache' ) ) {
 
 			require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 			dbDelta( $sql );
-
+			update_site_option( self::$table_version_key, '3' );
+			
 		} // END public static function activate
 
 		/**


### PR DESCRIPTION
If fresh install of REST Cache this never gets set and maybe_table_upgrade() gives DB errors as tables are present from activation and $query1 and $query2 are both false.